### PR TITLE
Cross compile projects for Scala and Scala.js

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+  - sbt '+ publishM2'

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
-addSbtPlugin("com.jsuereth"       % "sbt-pgp"              % "1.1.1")
-addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"         % "2.5")
-addSbtPlugin("com.github.gseitz"  % "sbt-release"          % "1.0.11")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.2.0")
+addSbtPlugin("com.jsuereth"       % "sbt-pgp"                  % "1.1.1")
+addSbtPlugin("org.xerial.sbt"     % "sbt-sonatype"             % "2.5")
+addSbtPlugin("com.github.gseitz"  % "sbt-release"              % "1.0.11")


### PR DESCRIPTION
Allows using `goggles` from Scala.js projects. I know a previous scala.js branch was reverted #44 due to it altering the project layout, on this PR I'm trying to keep things on their original place while still compiling to both platforms.

Now that `Scala.js 1` is on the wild it's much more easier to cross compile this project without changing the project structure.

- [x] Added plugin `sbt-crossproject` to target `Scala 1.2.0`
- [x] Configured `build.st` for cross compilation
   root projects have the setting `withoutSuffixFor(JVMPlatform)` so that you can use them directly without prefix
  ```
  sbt> dslProject/test
  ...
  [info] Passed: Total 141, Failed 0, Errors 0, Passed 141

  sbt> dslProjectJS/test
  [info] Passed: Total 141, Failed 0, Errors 0, Passed 141
  ```
- [x] Tests for `dslProject` are green on both JS and JVM platform
- [x] Tests for `macrosProject` are green and only run on JVM platform since they are a compile-time feature.
- [x] Upgraded `specs2` to version `4.10.3` which fully supports `scalajs1`.
- [x] Upgraded `monocle-core` to version `1.7.3` (latest major 1.x version that uses scalaz) that supports `scalajs1`
- [x] Added a `jitpack.yml` file so that we can fetch cross compiled artifacts from [jitpack.io](https://jitpack.io/#kenbot/goggles) for no-yet-released branches like this one.



